### PR TITLE
Prefer zipped .faa.gz

### DIFF
--- a/virtual_env/filter_empties.py
+++ b/virtual_env/filter_empties.py
@@ -1,4 +1,7 @@
+#!/usr/bin/env python
 # coding: utf-8
+
+# This script only reads .out files
 import os
 from util import *
 

--- a/virtual_env/ppm_motif_filter.py
+++ b/virtual_env/ppm_motif_filter.py
@@ -4,7 +4,7 @@ from util import parse_faa
 
 database = "Complete"
 
-FAA_PATH = '/Vagabundo/monica/temp/faa-' + database
+FAA_PATH = '/research/gmh/GENOME-DB/faa-' + database
 INPUT_PATH = '/Vagabundo/monica/temp/70-CUTGA-OUT-faa-' + database
 
 MOTIF_REGEX = 'EDK\w{3,7}NS'
@@ -34,7 +34,9 @@ if __name__ == '__main__':
     out_files = [f for f in os.listdir(INPUT_PATH) if f.endswith('.out')]
     for fname in out_files:
         gcf_id = fname.split('.')[0]
-        faa_fname = fname.split('.')[0] + '.faa'
+
+        # Use .faa.gz as extension, to read gzipped files with parse_faa
+        faa_fname = fname.split('.')[0] + '.faa.gz'
 
         faa_path = FAA_PATH + '/' + faa_fname
         if file_has_motif(faa_path, MOTIF_REGEX):

--- a/virtual_env/sort_matches.py
+++ b/virtual_env/sort_matches.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python
+
+# This script reads .out files only.
+
 from __future__ import print_function
 import os
 from util import *


### PR DESCRIPTION
For the compile_fasta* scripts, just pass a path that will have .faa.gz files (the /research/gmh/... path)

For other stuff, you'll have to set the faa_path variable in the script to that path, but it should be able to find and read them.

I'm not confident I hit everything with this. So if you think of any code I missed, lmk.